### PR TITLE
fix formatting and add an extra clarifying feature

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,11 @@ fn print_line(test : &str, input: &String, overwrite_line: bool) {
         if in_char == c.1 {
             print!("{color_blue}{}{color_reset}", c.1);
         } else {
-            print!("{color_red}{}{color_reset}", c.1);
+            if c.1 == ' ' {
+                print!("{color_red}_{color_reset}");
+            } else {
+                print!("{color_red}{}{color_reset}", c.1);
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ fn print_line(test : &str, input: &String, overwrite_line: bool) {
         if in_char == c.1 {
             print!("{color_blue}{}{color_reset}", c.1);
         } else {
-            print!{"{color_red}{}{color_reset}", c.1};
+            print!("{color_red}{}{color_reset}", c.1);
         }
     }
 }


### PR DESCRIPTION
- There was a print statement using braces instead of parenthesis, when all other print statements did not.
- Additionally, when a character is entered instead of a space, you have no idea that you entered an incorrect character. To combat this, I propose the idea of replacing it with a red coloured underscore.