### PR TITLE
fix: #3 by overwriting with whitespace

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,10 @@ fn print_line(test : &str, input: &String, overwrite_line: bool) {
             }
         }
     }
+
+    if input.len() == test.len() {
+        print!(" ");
+    }
 }
 
 fn accuracy(test: &String, input : &String) -> f64 {


### PR DESCRIPTION
This fixes the issue of ghost characters being displayed in stdout at the end of the programs life. The solution was as minimal as overwriting the space that this character would be displayed to with just whitespace.